### PR TITLE
New data types functionality and unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,4 +13,5 @@ source =
 # include = 
 
 # a list of file name patterns, the files to leave out of measurement or reporting.
-# omit = 
+omit = 
+    datatypes/__datatypes.py

--- a/__TESTS/unittests/datatypes/test_beam_data.py
+++ b/__TESTS/unittests/datatypes/test_beam_data.py
@@ -1,0 +1,122 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import numpy.testing as npTest
+import os
+import scipy.constants as cont
+import matplotlib.pyplot as plt
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+import blond_common.datatypes.beam_data as bDat
+from blond_common.devtools import exceptions
+
+class test_beam_data(unittest.TestCase):
+
+    def test_basic_beam_data(self):
+
+        func = bDat._beam_data(1, units='test')
+        expectDict = {'timebase': 'single', 'units': 'test',
+                      'interpolation': 'linear', 'bunching': 'single_bunch'}
+        self.assertEqual(func, 1, msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = bDat._beam_data(1, 1, units='test')
+        expectDict = {'timebase': 'single', 'units': 'test',
+                      'interpolation': 'linear', 'bunching': 'multi_bunch'}
+        np.testing.assert_array_equal(func, [1, 1],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = bDat._beam_data(1, 1, units = 'test', time=[1, 2])
+        expectDict = {'timebase': 'by_time', 'units': 'test',
+                      'interpolation': 'linear', 'bunching': 'multi_bunch'}
+        np.testing.assert_array_equal(func, [[[1, 2], [1, 1]],
+                                              [[1, 2], [1, 1]]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = bDat._beam_data(1, 1, units = 'test', n_turns=2)
+        expectDict = {'timebase': 'by_turn', 'units': 'test',
+                      'interpolation': 'linear', 'bunching': 'multi_bunch'}
+        np.testing.assert_array_equal(func, [[1, 1], [1, 1]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+
+    def test_acceptance(self):
+
+        func = bDat.acceptance(1)
+        expectDict = {'timebase': 'single', 'units': 'eVs',
+                      'interpolation': 'linear', 'bunching': 'single_bunch'}
+        self.assertEqual(func.data_type, expectDict, msg = 'data_type dict '
+                                                         +'contents incorrect')
+
+
+    def test_emittance(self):
+
+        func = bDat.emittance(1)
+        expectDict = {'timebase': 'single', 'units': 'eVs',
+                      'interpolation': 'linear', 'bunching': 'single_bunch',
+                      'emittance_type': 'matched_area'}
+        self.assertEqual(func.data_type, expectDict, msg = 'data_type dict '
+                                                         +'contents incorrect')
+
+
+    def test_length(self):
+
+        func = bDat.length(1)
+        expectDict = {'timebase': 'single', 'units': 's',
+                      'interpolation': 'linear', 'bunching': 'single_bunch',
+                      'length_type': 'full_length'}
+        self.assertEqual(func.data_type, expectDict, msg = 'data_type dict '
+                                                         +'contents incorrect')
+
+
+    def test_height(self):
+
+        func = bDat.height(1)
+        expectDict = {'timebase': 'single', 'units': 'eV',
+                      'interpolation': 'linear', 'bunching': 'single_bunch',
+                      'height_type': 'half_height'}
+        self.assertEqual(func.data_type, expectDict, msg = 'data_type dict '
+                                                          +'contents incorrect')
+
+
+    def test_synchronous_phase(self):
+
+        func = bDat.synchronous_phase(1)
+        expectDict = {'timebase': 'single', 'units': 's',
+                      'interpolation': 'linear', 'bunching': 'single_bunch'}
+        self.assertEqual(func.data_type, expectDict, msg = 'data_type dict '
+                                                         +'contents incorrect')
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/__TESTS/unittests/datatypes/test_core.py
+++ b/__TESTS/unittests/datatypes/test_core.py
@@ -1,0 +1,455 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import numpy.testing as npTest
+import os
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+import blond_common.datatypes._core as core
+from blond_common.devtools import exceptions
+
+class test_core(unittest.TestCase):
+
+    def test_creation(self):
+
+        core._function(np.array([1, 2, 3]), data_type = {},
+                                       interpolation = 'linear')
+        core._function(np.array([[1, 2, 3], [2, 3, 4]]), data_type = {})
+        core._function(np.zeros([3, 2, 10]), data_type = {})
+        core._function(np.array([[1, 2, 3], [2, 3]]), data_type = {})
+
+
+    def test_zeros(self):
+
+        test = core._function.zeros([3, 3])
+        self.assertEqual(len(test.shape), 2,
+                                 'length of test.shape should be 2')
+        self.assertEqual(test.shape[0], 3,
+                                 'first element of shape should be 3')
+        self.assertEqual(test.shape[1], 3,
+                                 'second element of shape should be 3')
+
+        self.assertIsNone(test.timebase, msg='timebase should be None')
+
+        test = core._function.zeros([3, 3], data_type = {'timebase': 'test'})
+        self.assertEqual(test.timebase, 'test',
+                                 msg='timebase has not been correctly set')
+
+        with self.assertRaises(exceptions.InputDataError, \
+                               msg='Passing an invalid parameter should ' \
+                               + 'raise an InputDataError'):
+
+            test = core._function.zeros([3, 3], data_type = {'fake_parameter':
+                                                                 'test'})
+
+    def test_slicing(self):
+
+        test = core._function.zeros(10, data_type={'timebase': 'fake'})
+        sliced = test[:5]
+
+        self.assertEqual(sliced.data_type['timebase'], 'fake',
+                             msg='sliced data_type not copied correctly')
+        self.assertIsInstance(sliced, core._function,
+                              msg='Type incorrect after slicing')
+
+
+    def test_copy(self):
+
+        test = core._function.zeros(10, data_type={'timebase': 'fake'})
+        copied = test.copy()
+
+        self.assertEqual(copied.data_type['timebase'], 'fake',
+                             msg='copied data_type not copied correctly')
+        self.assertIsInstance(copied, core._function,
+                                      msg='Type incorrect after copying')
+
+
+    def test_reshape_basic(self):
+
+        ############
+        #TIME BASED#
+        ############
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]]]),
+                           data_type={'timebase': 'by_time'},
+                           interpolation='linear')
+        test = test.reshape(1, [1.5], [1])
+        self.assertEqual(test, 1.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
+                                         [[1, 2, 3], [4, 5, 6]]]),
+                           data_type={'timebase': 'by_time'},
+                           interpolation='linear')
+        test = test.reshape(2, [1.5], [1])
+
+        self.assertEqual(test[0][0], 1.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][0], 4.5,
+                                 msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        ############
+        #TURN BASED#
+        ############
+        test = core._function(np.array([[1, 2, 3, 1, 2, 3]]),
+                           data_type={'timebase': 'by_turn'},
+                           interpolation='linear')
+        test = test.reshape(1, [1.5], use_turns = [1])
+        self.assertEqual(test, 2, msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        test = core._function(np.array([[1, 2, 3, 1, 2, 3],
+                                          [1, 2, 3, 4, 5, 6]]),
+                            data_type={'timebase': 'by_turn'},
+                            interpolation='linear')
+        test = test.reshape(2, use_time = [1.5, 2.5], use_turns = [1, 3])
+
+        self.assertEqual(test[0][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[0][1], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][1], 4,
+                                  msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        ###############
+        #SINGLE VALUED#
+        ###############
+        test = core._function(np.array([1]),
+                           data_type={'timebase': 'single'},
+                           interpolation='linear')
+        test = test.reshape(1, [1.5], use_turns = [1])
+        self.assertEqual(test, 1, msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+        test = core._function(np.array([1, 2, 3]),
+                            data_type={'timebase': 'single'},
+                            interpolation='linear')
+        test = test.reshape(3, use_time = [1.5, 2.5], use_turns = [1, 3])
+
+        self.assertEqual(test[0][0], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[0][1], 1,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][0], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[1][1], 2,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[2][0], 3,
+                                  msg='Interpolation not computed correctly')
+        self.assertEqual(test[2][1], 3,
+                                  msg='Interpolation not computed correctly')
+        self.assertIsInstance(test, core._function,
+                                  msg='Type incorrect after reshape')
+        self.assertEqual(test.timebase, 'interpolated',
+                         msg = 'After reshape timebase should be interpolated')
+
+
+    def test_reshape_store_time(self):
+
+        test = core._function(np.array([[[1, 2, 3], [1, 2, 3]],
+                                          [[1, 2, 3], [4, 5, 6]]]),
+                            data_type={'timebase': 'by_time'},
+                            interpolation='linear')
+        test = test.reshape(2, [1.5], store_time = True)
+
+        self.assertEqual(test.shape, (2, 2, 1),
+                             msg = 'The reshaped array has the wrong shape')
+        self.assertEqual(test[0,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[1,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[0,1,0], 1.5,
+                                     msg = 'The interpolation is incorrect')
+        self.assertEqual(test[1,1,0], 4.5,
+                                     msg = 'The interpolation is incorrect')
+
+        test = core._function(np.array([1, 2]),
+                              data_type={'timebase': 'single'},
+                              interpolation='linear')
+        test = test.reshape(2, [1.5], store_time = True)
+
+        self.assertEqual(test.shape, (2, 2, 1),
+                             msg = 'The reshaped array has the wrong shape')
+        self.assertEqual(test[0,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[1,0,0], 1.5,
+                                     msg = 'The new time axis is incorrect')
+        self.assertEqual(test[0,1,0], 1,
+                                     msg = 'The interpolation is incorrect')
+        self.assertEqual(test[1,1,0], 2,
+                                     msg = 'The interpolation is incorrect')
+
+        test = core._function.zeros([2, 3], data_type={'timebase':
+                                                           'by_turn'})
+        with self.assertRaises(exceptions.InputError, \
+                               msg='store_time should raise an InputError '
+                                   +'for a function defined by_turn'):
+            test.reshape(2, use_turns = [1], store_time = True)
+
+
+    def test_multiplication(self):
+
+        test = core._function(2, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test *= 5
+        self.assertEqual(test, 10, msg='Single value in place multiplication '
+                                         + 'incorrect')
+
+        test = core._function(2, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        self.assertEqual(test2, 4, msg='Single value multiplication '
+                                         + 'incorrect')
+        test2 = 2 * test
+        self.assertEqual(test2, 4, msg='Single value rmultiplication '
+                                         + 'incorrect')
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test *= 2
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by turn in place multiplication " +
+                                          "incorrect")
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn multiplication incorrect")
+        test2 = 2 * test
+        compare = [[2, 4, 6], [8, 10, 12]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn rmultiplication incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test *= 2
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by time in place multiplication "
+                                          + "incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test2 = test * 2
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time multiplication incorrect")
+        test2 = 2 * test
+        compare = [[[1, 2, 3], [8, 10, 12]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time rmultiplication incorrect")
+
+
+    def test_addition(self):
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test += 5
+        self.assertEqual(test, 6, msg='Single value in place addition '
+                                         + 'incorrect')
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        self.assertEqual(test2, 2, msg='Single value addition '
+                                         + 'incorrect')
+        test2 = 1 + test
+        self.assertEqual(test2, 2, msg='Single value raddition '
+                                         + 'incorrect')
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test += 5
+        compare = [[6, 7, 8], [9, 10, 11]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by turn in place addition incorrect")
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        compare = [[2, 3, 4], [5, 6, 7]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn addition incorrect")
+        test2 = 1 + test
+        compare = [[2, 3, 4], [5, 6, 7]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn raddition incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test += 5
+        compare = [[[1, 2, 3], [9, 10, 11]]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by time in place addition incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test2 = test + 1
+        compare = [[[1, 2, 3], [5, 6, 7]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time addition incorrect")
+        test2 = 1 + test
+        compare = [[[1, 2, 3], [5, 6, 7]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time raddition incorrect")
+
+
+    def test_subtraction(self):
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test -= 5
+        self.assertEqual(test, -4, msg='Single value in place subtraction '
+                                         + 'incorrect')
+
+        test = core._function(1, data_type = {'timebase': 'single'},
+                              interpolation = 'linear')
+        test2 = test - 1
+        self.assertEqual(test2, 0, msg='Single value subtraction '
+                                         + 'incorrect')
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test -= 5
+        compare = [[-4, -3, -2], [-1, 0, 1]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by turn in place subtraction incorrect")
+
+        test = core._function([[1, 2, 3], [4, 5, 6]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+        test2 = test - 1
+        compare = [[0, 1, 2], [3, 4, 5]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by turn subtraction incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test -= 5
+        compare = [[[1, 2, 3], [-1, 0, 1]]]
+        npTest.assert_array_equal(test, compare,
+                              err_msg = "by time in place subtraction incorrect")
+
+        test = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+        test2 = test - 1
+        compare = [[[1, 2, 3], [3, 4, 5]]]
+        npTest.assert_array_equal(test2, compare,
+                              err_msg = "by time subtraction incorrect")
+
+
+    def test_exceptions(self):
+
+        test1 = core._function([[[1, 2, 3], [4, 5, 6]]],
+                              data_type = {'timebase': 'by_time'},
+                              interpolation = 'linear')
+
+        test2 = core._function([[1, 2, 3]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+
+        with self.assertRaises(TypeError, msg='addition with different '
+                               + 'data_type dicts should raise a TypeError'):
+            test1 += test2
+        with self.assertRaises(TypeError, msg='subtraction with different '
+                               + 'data_type dicts should raise a TypeError'):
+            test1 -= test2
+        with self.assertRaises(TypeError, msg='multiplication with different '
+                               + 'data_type dicts should raise a TypeError'):
+            test1 *= test2
+        with self.assertRaises(TypeError, msg='division with different '
+                               + 'data_type dicts should raise a TypeError'):
+            test1 /= test2
+
+        with self.assertRaises(exceptions.InputDataError, msg='unrecognised '
+                               +'data_type dict options should raise an '
+                               +'InputDataError.'):
+            core._function(1, data_type = {'fake_option_string': None},
+                              interpolation = 'linear')
+
+        with self.assertRaises(exceptions.InputError, msg='_prep_reshape '
+                               +'with use_time=None and use_turns=None should '
+                               'raise an InputError.'):
+            test1._prep_reshape(1)
+
+        with self.assertRaises(exceptions.InputError, msg='_prep_reshape '
+                               +'with use_turns should raise an InputError if'
+                               +' timebase == "by_time"'):
+            test1._prep_reshape(1, use_turns=[1, 2])
+
+        with self.assertRaises(exceptions.InputError, msg='_prep_reshape '
+                               +'with use_time should raise an InputError if'
+                               +' timebase == "by_turn"'):
+            test2._prep_reshape(1, use_time=[1, 2])
+
+
+
+        test3 = core._function([[1, 2, 3], [1, 2, 3]],
+                              data_type = {'timebase': 'by_turn'},
+                              interpolation = 'linear')
+
+        with self.assertRaises(exceptions.DataDefinitionError,
+                               msg='_comp_definition_reshape with n_sections'
+                               +'!= shape[0] and shape[0]>1 should raise a '
+                               +'DataDefinitionError'):
+            test3._comp_definition_reshape(3, use_time = None, use_turns=[1, 2])
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/__TESTS/unittests/datatypes/test_functions.py
+++ b/__TESTS/unittests/datatypes/test_functions.py
@@ -1,0 +1,95 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import numpy.testing as npTest
+import os
+import scipy.constants as cont
+import matplotlib.pyplot as plt
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+
+import blond_common.datatypes._core as core
+import blond_common.datatypes.ring_programs as rProg
+import blond_common.datatypes.functions as funcs
+from blond_common.devtools import exceptions
+
+
+class test_functions(unittest.TestCase):
+
+    def test_vstack(self):
+
+        alpha0_0 = rProg.momentum_compaction(0, time = [0, 1])
+        alpha0_1 = rProg.momentum_compaction(1, time = [2, 3])
+
+        alpha0 = funcs.vstack(alpha0_0, alpha0_1)
+        expectDict = {'timebase': 'by_time', 'sectioning': 'single_section',
+                      'order': 0, 'interpolation': 'linear'}
+        expectArray = [[[0, 1, 2, 3], [0, 0, 1, 1]]]
+
+        self.assertEqual(alpha0.data_type, expectDict, msg='Final data_type '
+                         +'dict does not match expected')
+        np.testing.assert_array_equal(alpha0, expectArray, err_msg = 'Stacked'
+                                      +' array does not match expected.')
+
+        alpha0_0 = rProg.momentum_compaction(0, 1, time = [0, 1, 2, 3])
+        alpha0_1 = rProg.momentum_compaction(1, 0, time = [5, 6, 7])
+
+        alpha0 = funcs.vstack((1, alpha0_0), (5.5, alpha0_1, 8))
+        expectDict = {'timebase': 'by_time', 'sectioning': 'multi_section',
+                      'order': 0, 'interpolation': 'linear'}
+        expectArray = [[[1, 2, 3, 5.5, 6, 7, 8], [0, 0, 0, 1, 1, 1, 1]],
+                       [[1, 2, 3, 5.5, 6, 7, 8], [1, 1, 1, 0, 0, 0, 0]]]
+
+        self.assertEqual(alpha0.data_type, expectDict, msg='Final data_type '
+                         +'dict does not match expected')
+        np.testing.assert_array_equal(alpha0, expectArray, err_msg = 'Stacked'
+                                      +' array does not match expected.')
+
+        with self.assertRaises(exceptions.InputError, msg='Non stackable '
+                               +'input should raise an InputError'):
+            funcs.vstack(1, 2)
+
+        with self.assertRaises(exceptions.InputError, msg='Input without a '
+                               +'datatype array should raise in InputError'):
+            funcs.vstack(alpha0_0, (2, 3))
+
+        with self.assertRaises(exceptions.InputError, msg='Wrong length input '
+                               +'should raise in InputError'):
+            funcs.vstack(alpha0_0, (2, alpha0_1, 3, 4))
+
+        with self.assertRaises(RuntimeError, msg='Non-monotonically '
+                           +'increasing times should raise a RuntimeError'):
+            funcs.vstack(alpha0_0, (2, alpha0_1, 3))
+
+        alpha1_0 = alpha0_0.copy()
+        alpha1_0.order = 1
+        with self.assertRaises(exceptions.InputError, msg='Mismatched '
+                               +'data_type should raise in InputError'):
+            funcs.vstack(alpha0_0, alpha1_0)
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/__TESTS/unittests/datatypes/test_rf_programs.py
+++ b/__TESTS/unittests/datatypes/test_rf_programs.py
@@ -1,0 +1,176 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import numpy.testing as npTest
+import os
+import scipy.constants as cont
+import matplotlib.pyplot as plt
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+import blond_common.datatypes.rf_programs as rfProg
+from blond_common.devtools import exceptions
+
+class test_rf_programs(unittest.TestCase):
+
+    def test_basic_rf_function(self):
+
+        func = rfProg._RF_function(1, harmonics = 1)
+        expectDict = {'timebase': 'single', 'harmonics': (1,),
+                      'interpolation': 'linear'}
+        self.assertEqual(func, 1, msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = rfProg._RF_function(1, 1, harmonics = [1, 2])
+        expectDict = {'timebase': 'single', 'harmonics': [1, 2],
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func, [1, 1],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = rfProg._RF_function(1, 1, harmonics = [1, 2], time=[1, 2])
+        expectDict = {'timebase': 'by_time', 'harmonics': [1, 2],
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func, [[[1, 2], [1, 1]],
+                                             [[1, 2], [1, 1]]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func = rfProg._RF_function(1, 1, harmonics = [1, 2], n_turns=2)
+        expectDict = {'timebase': 'by_turn', 'harmonics': [1, 2],
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func, [[1, 1], [1, 1]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+
+    def test_reshape(self):
+
+        func = rfProg._RF_function([2, 4], harmonics = 1, time=[1, 2])
+
+        func2 = func.reshape(use_time = [1.5])
+        expectDict = {'timebase': 'interpolated', 'harmonics': (1,),
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func2, [[3]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func2.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        func2 = func.reshape(harmonics = [1, 2], use_time = [1.5])
+        expectDict = {'timebase': 'interpolated', 'harmonics': [1, 2],
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func2, [[3], [0]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func2.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        with self.assertRaises(exceptions.InputError,
+                               msg='Reshape with use_turns only should raise'
+                               + 'InputError for a "by_time" function'):
+            func.reshape(use_turns = [1, 2, 3])
+
+        func = rfProg._RF_function([2, 4], harmonics = 1)
+
+        func2 = func.reshape(use_turns=[1])
+        expectDict = {'timebase': 'interpolated', 'harmonics': (1,),
+                      'interpolation': 'linear'}
+        np.testing.assert_array_equal(func2, [[4]],
+                                      err_msg='Function value incorrect')
+        self.assertEqual(func2.data_type, expectDict, 'data_type dict contents'
+                                                    +' incorrect')
+
+        with self.assertRaises(exceptions.InputError,
+                               msg='Reshape with use_time only should raise'
+                               + 'InputError for a "by_turn" function'):
+            func.reshape(use_time = [1, 2, 3])
+
+
+    def test_voltage_phase(self):
+
+        volts = rfProg.voltage_program([1, 2, 3], harmonics = 1)
+        phase = rfProg.phase_program([1, 1, 1], harmonics = 2)
+
+        vDict = {'timebase': 'by_turn', 'harmonics': (1,),
+                 'interpolation': 'linear'}
+        pDict = {'timebase': 'by_turn', 'harmonics': (2,),
+                 'interpolation': 'linear'}
+
+        self.assertEqual(volts.data_type, vDict,
+                         msg = 'volts data_type dict incorrect')
+        self.assertEqual(phase.data_type, pDict,
+                         msg = 'phase data_type dict incorrect')
+
+
+    def test_phase_offset(self):
+
+        pOff = rfProg.phase_offset([0, 0.1, 0.1], harmonics = 1,
+                                   time = [0, 0.1, 0.2])
+        omegaRev = np.array([np.linspace(0, 0.2, 10), [2*np.pi*1E6]*10])
+
+        oOff = pOff.calc_delta_omega(omegaRev)
+
+        expectDict = {'timebase': 'interpolated', 'harmonics': (1,),
+                      'interpolation': 'linear'}
+        expectArray = np.array([[1E6, 1E6, 1E6, 1E6, 0.75E6, 0.25E6, 0, 0, 0,
+                                 0]])
+        self.assertEqual(oOff.shape, (1, 10), msg='Calculated phase offset '
+                                                 +'shape is incorrect')
+        self.assertEqual(oOff.data_type, expectDict, msg='Calculated phase '
+                                                        +'offset data_type '
+                                                        +'dict incorrect')
+        np.testing.assert_array_almost_equal(oOff, expectArray,
+                                             err_msg='Calcualted phase offset'
+                                                    +' array values incorrect')
+
+
+    def test_omega_offest(self):
+
+        oOff = rfProg.omega_offset([0, 1E6, 0], time = [0, 0.1, 0.2],
+                                   harmonics = 1)
+        omegaRev = np.array([np.linspace(0, 0.2, 10), [2*np.pi*1E6]*10])
+
+        pOff = oOff.calc_delta_phase(omegaRev)
+
+        expectDict = {'timebase': 'interpolated', 'harmonics': (1,),
+                      'interpolation': 'linear'}
+        expectArray = np.array([[0, 0.00493827, 0.01481481, 0.02962963,
+                                 0.04938272, 0.0691358, 0.08395062,
+                                 0.09382716, 0.09876543, 0.09876543]])
+        self.assertEqual(pOff.shape, (1, 10), msg='Calculated phase offset '
+                                                 +'shape is incorrect')
+        self.assertEqual(pOff.data_type, expectDict, msg='Calculated phase '
+                                                        +'offset data_type '
+                                                        +'dict incorrect')
+        np.testing.assert_array_almost_equal(pOff, expectArray,
+                                             err_msg='Calcualted phase offset'
+                                                    +' array values incorrect')
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/__TESTS/unittests/datatypes/test_ring_programs.py
+++ b/__TESTS/unittests/datatypes/test_ring_programs.py
@@ -1,0 +1,427 @@
+# coding: utf8
+# Copyright 2019 CERN. This software is distributed under the
+# terms of the GNU General Public Licence version 3 (GPL Version 3),
+# copied verbatim in the file LICENCE.md.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+# Project website: http://blond.web.cern.ch/
+
+'''
+Test dataypes._core.py
+
+'''
+
+# General imports
+# ---------------
+import sys
+import unittest
+import numpy as np
+import numpy.testing as npTest
+import os
+import scipy.constants as cont
+
+this_directory = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+# BLonD_Common imports
+# --------------------
+if os.path.abspath(this_directory + '../../../../') not in sys.path:
+    sys.path.insert(0, os.path.abspath(this_directory + '../../../../'))
+
+import blond_common.datatypes.ring_programs as ringProg
+from blond_common.devtools import exceptions
+
+class test_ring_programs(unittest.TestCase):
+
+    def test_basic_ring_function_creation(self):
+
+        func = ringProg._ring_function(1E9)
+        expectDict = {'timebase': 'single', 'sectioning': 'single_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (1,), 'Single value shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                     +' incorrect')
+
+        func = ringProg._ring_function([1E9, 1E9], [1E9, 1E9])
+        expectDict = {'timebase': 'by_turn', 'sectioning': 'multi_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (2, 2), 'Multi-section by turn shape '
+                                           + 'incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                     +' incorrect')
+
+        func = ringProg._ring_function([1E9, 1E9], time = [0, 1])
+        expectDict = {'timebase': 'by_time', 'sectioning': 'single_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (1, 2, 2), 'Single-section by time shape '
+                                              + 'incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                     +' incorrect')
+
+        func = ringProg._ring_function([[0, 1], [1E9, 1E9]],
+                                        [[0, 1], [1E9, 1E9]])
+        expectDict = {'timebase': 'by_time', 'sectioning': 'multi_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (2, 2, 2), 'Multi-section by time shape '
+                                              + 'incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+        func = ringProg._ring_function(1, n_turns = 100)
+        expectDict = {'timebase': 'by_turn', 'sectioning': 'single_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (1, 100), 'single section by turn '
+                                              +'expanded shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+        func = ringProg._ring_function(1, time = [0, 1])
+        expectDict = {'timebase': 'by_time', 'sectioning': 'single_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (1, 2, 2), 'single section by turn '
+                                              +'expanded shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+        func = ringProg._ring_function(1, 2, time = [0, 1])
+        expectDict = {'timebase': 'by_time', 'sectioning': 'multi_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (2, 2, 2), 'multi section by turn '
+                                              +'expanded shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+
+    def test_mixed_input(self):
+
+        with self.assertRaises(exceptions.DataDefinitionError, \
+                               msg='Declaring a mix of turn based and single'
+                                 + ' valued input should raise a '
+                                 + 'DataDefinitionError with default of '
+                                 + 'allow_single = False'):
+            func = ringProg._ring_function(1, [1, 2])
+
+        func = ringProg._ring_function(1, [1, 2], allow_single = True)
+        expectDict = {'timebase': 'by_turn', 'sectioning': 'multi_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (2, 2), 'multi section by turn '
+                                              +'expanded shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+        with self.assertRaises(exceptions.DataDefinitionError, \
+                               msg='Declaring a mix of time based and single'
+                                 + ' valued input should raise a '
+                                 + 'DataDefinitionError with default of '
+                                 + 'allow_single = False'):
+            func = ringProg._ring_function(1, [[0, 1], [1, 2]])
+
+        func = ringProg._ring_function(1, [[0, 1], [1, 2]], allow_single=True)
+        expectDict = {'timebase': 'by_time', 'sectioning': 'multi_section',
+                      'interpolation': None}
+        self.assertEqual(func.shape, (2, 2, 2), 'multi section by time '
+                                              +'expanded shape incorrect')
+        self.assertEqual(func.data_type, expectDict, 'data_type dict contents'
+                                                      +' incorrect')
+
+
+    def test_synchronous_data(self):
+
+        mom = ringProg.momentum_program(1E9)
+        totEn = ringProg.total_energy_program([2E9]*10)
+        kinEn = ringProg.kinetic_energy_program([[0, 1], [160E6, 1E9]])
+        bend = ringProg.bending_field_program(0.5, n_turns = 1000)
+
+        self.assertEqual(mom.source, 'momentum', msg='momentum_program source'
+                                                 + ' str incorrect')
+        self.assertEqual(totEn.source, 'energy', msg='momentum_program source'
+                                                 + ' str incorrect')
+        self.assertEqual(kinEn.source, 'kin_energy', msg='momentum_program'
+                                                 + ' source str incorrect')
+        self.assertEqual(bend.source, 'B_field', msg='momentum_program source'
+                                                 + ' str incorrect')
+
+        conversions = {'momentum': ringProg.momentum_program,
+                       'energy': ringProg.total_energy_program,
+                       'kin_energy': ringProg.kinetic_energy_program,
+                       'B_field': ringProg.bending_field_program}
+
+        self.assertEqual(mom._conversions, conversions,
+                         msg = 'Momentum program _conversions dict incorrect')
+        self.assertEqual(totEn._conversions, conversions,
+                         msg = 'Energy program _conversions dict incorrect')
+        self.assertEqual(kinEn._conversions, conversions,
+                         msg = 'KinEnergy program _conversions dict incorrect')
+        self.assertEqual(bend._conversions, conversions,
+                         msg = 'B Field program _conversions dict incorrect')
+
+        m_p = cont.physical_constants['proton mass energy equivalent in MeV']
+        m_p = m_p[0]*1E6
+
+        #TODO: Check values and permutations
+        ringProg.momentum_program.combine_single_sections(mom, mom)
+        ringProg.momentum_program.combine_single_sections(totEn, totEn,
+                                                          rest_mass = m_p)
+        ringProg.momentum_program.combine_single_sections(kinEn, kinEn,
+                                                          rest_mass = m_p,
+                                                        interpolation='linear')
+        ringProg.momentum_program.combine_single_sections(bend, bend,
+                                                          charge = 1,
+                                                          bending_radius = 8)
+
+
+    def test_synchronous_conversions(self):
+
+        m_p = cont.physical_constants['proton mass energy equivalent in MeV']
+        m_p = m_p[0]*1E6
+        charge = 1
+        rho = 8.7
+
+        ###############
+        #FROM MOMENTUM#
+        ###############
+        mom = ringProg.momentum_program(1E9)
+
+        newB = mom.to_B_field(False, bending_radius = rho, charge = charge)
+        self.assertIsInstance(newB, ringProg.bending_field_program,
+                              msg = 'type cast to bending_field_program '
+                                  + 'incorrect')
+        self.assertAlmostEqual(newB[0], 0.38340701, places = 4,
+                               msg='P to B conversion inaccurate')
+        self.assertEqual(newB.data_type, mom.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newE = mom.to_total_energy(False, rest_mass = m_p)
+        self.assertIsInstance(newE, ringProg.total_energy_program,
+                              msg = 'type cast to total_energy_program '
+                                  + 'incorrect')
+        self.assertAlmostEqual(newE[0]/1E9, 1.37126019, places = 4,
+                               msg='P to E conversion inaccurate')
+        self.assertEqual(newE.data_type, mom.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newKE = mom.to_kin_energy(False, rest_mass = m_p)
+        self.assertIsInstance(newKE, ringProg.kinetic_energy_program,
+                              msg = 'type cast to kinetic_energy_program '
+                                  + 'incorrect')
+        self.assertAlmostEqual(newKE[0]/1E8, 4.32988103, places = 4,
+                               msg='P to KE conversion inaccurate')
+        self.assertEqual(newKE.data_type, mom.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+        newP = mom.to_momentum(False)
+        self.assertIsInstance(newP, ringProg.momentum_program,
+                              msg = 'type cast to momentum_program '
+                                  + 'incorrect')
+        self.assertAlmostEqual(newP[0]/1E8, mom[0]/1E8, places = 9,
+                               msg='P to P conversion inaccurate')
+        self.assertEqual(newP.data_type, mom.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+
+        ####################
+        #FROM BENDING FIELD#
+        ####################
+        B = ringProg.bending_field_program([0.5, 0.5])
+
+        newP = B.to_momentum(False, bending_radius = rho, charge = charge)
+        self.assertIsInstance(newP, ringProg.momentum_program,
+                              msg = 'type cast to momentum_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newP/1E9, [[1.30409719]*2],
+                                             decimal = 4, err_msg='B to P '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newP.data_type, B.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newE = B.to_total_energy(False, rest_mass = m_p, bending_radius = rho,
+                                 charge = 1)
+        self.assertIsInstance(newE, ringProg.total_energy_program,
+                              msg = 'type cast to total_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newE/1E9, [[1.60655657]*2],
+                                             decimal = 4, err_msg='B to E '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newE.data_type, B.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newKE = B.to_kin_energy(False, rest_mass = m_p, bending_radius = rho,
+                                 charge = 1)
+        self.assertIsInstance(newKE, ringProg.kinetic_energy_program,
+                              msg = 'type cast to kinetic_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newKE/1E8, [[6.68284477]*2],
+                                             decimal = 4, err_msg='B to KE '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newKE.data_type, B.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+        newB = B.to_B_field(False)
+        self.assertIsInstance(newB, ringProg.bending_field_program,
+                              msg = 'type cast to bending_field_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newB, B,
+                                             decimal = 9, err_msg='B to B '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newB.data_type, B.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+
+        ###################
+        #FROM TOTAL ENERGY#
+        ###################
+        E = ringProg.total_energy_program(2E9, 2E9, time = [0, 1])
+
+        compareArray = np.zeros([2, 2, 2])
+        compareArray[:,0] = [0, 1]
+
+        newP = E.to_momentum(False, rest_mass = m_p)
+        compareArray[:,1] = 1.76625182
+        self.assertIsInstance(newP, ringProg.momentum_program,
+                              msg = 'type cast to momentum_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newP/1E9, compareArray,
+                                             decimal = 4, err_msg='E to P '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newP.data_type, E.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newB = E.to_B_field(False, rest_mass = m_p, bending_radius = rho,
+                            charge = 1)
+        compareArray[:,1] = 0.67719332
+        self.assertIsInstance(newB, ringProg.bending_field_program,
+                              msg = 'type cast to bending_field_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newB, compareArray,
+                                             decimal = 4, err_msg='E to B '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newE.data_type, B.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newKE = E.to_kin_energy(False, rest_mass = m_p)
+        compareArray[:,1] = 1.06172791
+        self.assertIsInstance(newKE, ringProg.kinetic_energy_program,
+                              msg = 'type cast to kinetic_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newKE/1E9, compareArray,
+                                             decimal = 4, err_msg='E to KE '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newKE.data_type, E.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+        newE = E.to_total_energy(False)
+        compareArray[:,1] = E[:,1]
+        self.assertIsInstance(newE, ringProg.total_energy_program,
+                              msg = 'type cast to total_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newE, compareArray,
+                                             decimal = 9, err_msg='E to E '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newE.data_type, E.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+
+        #####################
+        #FROM KINETIC ENERGY#
+        #####################
+        KE = ringProg.kinetic_energy_program([160E6, 250E6], [160E6, 250E6])
+
+        compareArray = np.zeros([2, 2])
+
+        newP = KE.to_momentum(False, rest_mass = m_p)
+        compareArray[:,0] = 5.70830157
+        compareArray[:,1] = 7.29133763
+        self.assertIsInstance(newP, ringProg.momentum_program,
+                              msg = 'type cast to momentum_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newP/1E8, compareArray,
+                                             decimal = 4, err_msg='KE to P '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newP.data_type, KE.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newB = KE.to_B_field(False, rest_mass = m_p, bending_radius = rho,
+                             charge = 1)
+        compareArray[:,0] = 0.21886028
+        compareArray[:,1] = 0.27955499
+        self.assertIsInstance(newB, ringProg.bending_field_program,
+                              msg = 'type cast to bending_field_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newB, compareArray,
+                                             decimal = 4, err_msg='KE to B '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newB.data_type, KE.data_type,
+                         msg = 'data_type dict not copied correctly')
+
+        newE = KE.to_total_energy(False, rest_mass = m_p)
+        compareArray[:,0] = 1.09827209
+        compareArray[:,1] = 1.18827209
+        self.assertIsInstance(newE, ringProg.total_energy_program,
+                              msg = 'type cast to total_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newE/1E9, compareArray,
+                                             decimal = 4, err_msg='KE to E '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newE.data_type, KE.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+        newKE = KE.to_kin_energy(False)
+        compareArray[:,0] = KE[:,0]
+        compareArray[:,1] = KE[:,1]
+        self.assertIsInstance(newKE, ringProg.kinetic_energy_program,
+                              msg = 'type cast to kinetic_energy_program '
+                                  + 'incorrect')
+        np.testing.assert_array_almost_equal(newKE, compareArray,
+                                             decimal = 9, err_msg='KE to E '
+                                             + 'conversion inaccurate')
+        self.assertEqual(newKE.data_type, KE.data_type,
+                          msg = 'data_type dict not copied correctly')
+
+
+    def test_momentum_compaction(self):
+
+        alpha0 = ringProg.momentum_compaction(1)
+        expectDType = {'timebase': 'single', 'order': 0,
+                       'interpolation': 'linear',
+                       'sectioning': 'single_section'}
+        self.assertEqual(alpha0.data_type, expectDType,
+                         msg='Data type dictionary does not match expected')
+
+        alpha1 = ringProg.momentum_compaction([1, 2], order=1)
+        expectDType = {'timebase': 'by_turn', 'order': 1,
+                       'interpolation': 'linear',
+                       'sectioning': 'single_section'}
+        self.assertEqual(alpha1.data_type, expectDType,
+                         msg='Data type dictionary does not match expected')
+
+        with self.assertRaises(exceptions.InputError,
+                           msg='momentum_compaction.combine_single_sections '
+                              +'should raise an InputError if different orders'
+                              +' of alpha are given.'):
+            ringProg.momentum_compaction.combine_single_sections(alpha0,
+                                                                 alpha1)
+
+        alpha0_2 = ringProg.momentum_compaction(1, [1, 2])
+        expectDType = {'timebase': 'by_turn', 'order': 0,
+                       'interpolation': 'linear',
+                       'sectioning': 'multi_section'}
+        self.assertEqual(alpha0_2.data_type, expectDType,
+                         msg='Data type dictionary does not match expected')
+
+        alpha1_2 = ringProg.momentum_compaction(1, time = [1, 2], order=1)
+        expectDType = {'timebase': 'by_time', 'order': 1,
+                       'interpolation': 'linear',
+                       'sectioning': 'single_section'}
+        self.assertEqual(alpha1_2.data_type, expectDType,
+                         msg='Data type dictionary does not match expected')
+
+        with self.assertRaises(exceptions.InputError,
+                           msg='momentum_compaction.combine_single_sections '
+                              +'should raise an InputError if different '
+                              +'timebases are used.'):
+            ringProg.momentum_compaction.combine_single_sections(alpha1,
+                                                                 alpha1_2)
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/__TESTS/unittests/interfaces/impedances/test_impedance_sources.py
+++ b/__TESTS/unittests/interfaces/impedances/test_impedance_sources.py
@@ -97,11 +97,11 @@ class TestImpedanceSources(unittest.TestCase):
 
         imp = impSource._InputTable([1, 2, 3], [4, 5, 6], [7, 8, 9])
         
-        self.assertEqual(imp.frequency_array_loaded.tolist(), [1, 2, 3], 
+        self.assertEqual(imp.frequency_array_loaded.tolist(), [0, 1, 2, 3], 
                          "Expected frequency array to to be [0, 1, 2, 3]")
-        self.assertEqual(imp.Re_Z_array_loaded.tolist(), [4, 5, 6], 
+        self.assertEqual(imp.Re_Z_array_loaded.tolist(), [0, 4, 5, 6], 
                          "Expected real impedance array to be [0, 4, 5, 6]")
-        self.assertEqual(imp.Im_Z_array_loaded.tolist(), [7, 8, 9], 
+        self.assertEqual(imp.Im_Z_array_loaded.tolist(), [0, 7, 8, 9], 
                          "Expected imag impedance array to be [0, 7, 8, 9]")
 
         self.assertEqual(imp.time_array, 0, "Expected time array to be 0")

--- a/beam_dynamics/bucket.py
+++ b/beam_dynamics/bucket.py
@@ -35,9 +35,9 @@ from ..maths import calculus as calc
 
 
 class Bucket:
-    
+
     def __init__(self, time, well, beta, energy, eta, isSub = False):
-        
+
         self.beta = beta
         self.energy = energy
         self.eta = eta
@@ -48,108 +48,113 @@ class Bucket:
             self.time = self.time_loaded.copy()
             self.well = self.well_loaded.copy()
             return
-        
+
         try:
-            assrt.equal_array_lengths(time, well, 
+            assrt.equal_array_lengths(time, well,
                               msg = "time and well must have the same length",
                               exception = excpt.InputError)
         except TypeError:
             raise excpt.InputError("time and well must both be iterable")
-        
+
         orderedTime, orderedWell = pot.sort_potential_wells(time, well)
-        
+
         self.time_loaded = np.array(orderedTime[0], dtype=float)
         self.well_loaded = np.array(orderedWell[0], dtype=float)
-        
+
         self.time = self.time_loaded.copy()
         self.well = self.well_loaded.copy()
-        
+
         self.calc_separatrix()
         self.basic_parameters()
-        
+
         self.inner_times = orderedTime[1:]
         self.inner_wells = orderedWell[1:]
-        
+
         self._identify_substructure()
 
 
     @classmethod
     def from_dicts(cls, rfDict, machDict, tLeft = None, tRight = None,
-                   potential_resolution = 1000, induced_voltage = None):
-        
+                   potential_resolution = 1000, induced_voltage = None,
+                   expected_phi_s = None):
+
         if tRight is None:
             tRight = 1.05*machDict['t_rev']
         if tLeft is None:
             tLeft = 0 - 0.05*tRight
-        
+
         timeBounds = (tLeft, tRight)
-        
+
         vTime, vWave = pot.rf_voltage_generation(potential_resolution,
                                                  machDict['t_rev'],
                                                  rfDict['voltage'],
                                                  rfDict['harmonic'],
                                                  rfDict['phi_rf_d'],
                                                  time_bounds = timeBounds)
-        
+
         if induced_voltage is not None:
             vWave += np.interp(vTime, induced_voltage[0], induced_voltage[1])
-        
-        time, well, _ = pot.rf_potential_generation_cubic(vTime, vWave, 
-                                                          machDict['eta_0'], 
+
+        time, well, _ = pot.rf_potential_generation_cubic(vTime, vWave,
+                                                          machDict['eta_0'],
                                                           machDict['charge'],
-                                                          machDict['t_rev'], 
+                                                          machDict['t_rev'],
                                                           machDict['delta_E'])
-        
+
         well -= np.min(well)
         maxLocs, _, _, _, _ = pot.find_potential_wells_cubic(time, well,
                                  relative_max_val_precision_limit=1E-4)
 
         times, wells = pot.potential_well_cut_cubic(time, well, maxLocs)
-        
+
+        if expected_phi_s is not None:
+            times, wells = pot.choose_potential_wells(expected_phi_s, times,
+                                                      wells)
+
         return cls(times, wells, machDict['beta'], machDict['energy'],
                    machDict['eta_0'])
-    
+
 
     def _identify_substructure(self):
-        
+
         contains = [[] for i in range(len(self.inner_times))]
         for times, c in zip(self.inner_times, contains):
             c += [i for i in range(len(self.inner_times)) if self.inner_times[i][0] >= times[0]\
                                                       and self.inner_times[i][-1] <= times[-1]\
                                                       and self.inner_times[i] is not times]
-        
+
         exclude = [[] for i in range(len(self.inner_times))]
         for exc, cont in zip(exclude, contains):
             for c in cont:
                 exc += contains[c]
-        
+
         useCont = [[] for i in range(len(self.inner_times))]
         for i in range(len(self.inner_times)):
                 useCont[i] += [c for c in contains[i] if c not in exclude[i]]
-        
+
         bucketDict = {i: self.__class__(t, w, self.beta, self.energy,
-                                        self.eta, isSub=True) for i, (t, w) in 
+                                        self.eta, isSub=True) for i, (t, w) in
                           enumerate(zip(self.inner_times, self.inner_wells))}
-        
+
         nextLayer = []
         for i in range(len(self.inner_times)):
             if not any(i in c for c in useCont):
                 nextLayer.append(i)
-        
+
         if len(nextLayer) > 0:
             self.hasSubs = True
         else:
             self.hasSubs = False
-        
+
         self.sub_buckets = [bucketDict[i] for i in nextLayer]
-        
+
         for i, u in enumerate(useCont):
             bucketDict[i].sub_buckets = [bucketDict[c] for c in u]
             if len(u) > 0:
                 bucketDict[i].hasSubs = True
             else:
                 bucketDict[i].hasSubs = False
-        
+
         self._calc_inner_max()
         self._calc_inner_start()
         self._calc_inner_stop()
@@ -162,73 +167,73 @@ class Bucket:
             self.inner_max = np.max([np.max(b.well) for b in self.sub_buckets])
         else:
             self.inner_max = np.NaN
-    
+
     @deco.recursive_function
     def _calc_inner_start(self):
         if self.hasSubs:
             self.inner_start = np.min([np.min(b.time) for b in self.sub_buckets])
         else:
             self.inner_start = np.NaN
-    
+
     @deco.recursive_function
     def _calc_inner_stop(self):
         if self.hasSubs:
             self.inner_stop = np.max([np.max(b.time) for b in self.sub_buckets])
         else:
             self.inner_stop = np.NaN
-    
+
     @deco.recursive_function
     def _calc_minimum(self):
-        self.minimum = np.min(calc.minmax_location_cubic(self.time, 
+        self.minimum = np.min(calc.minmax_location_cubic(self.time,
                                                          self.well)[1][0])
-    
-    
+
+
     def inner_buckets(self):
-        
+
         self.inner_separatrices = []
         for t, w in zip(self.inner_times, self.inner_wells):
             hamil = pot.potential_to_hamiltonian(t, w,
-                                             self.beta, self.energy, 
+                                             self.beta, self.energy,
                                              self.eta)
 
             upper_energy_bound = np.sqrt(hamil)
-        
+
             sepTime = t.tolist() + t[::-1].tolist()
             sepEnergy = upper_energy_bound.tolist() \
                     + (-upper_energy_bound[::-1]).tolist()
-        
+
             self.inner_separatrices.append(np.array([sepTime, sepEnergy]))
 
 
     def smooth_well(self, nPoints = None, reinterp=False):
-    
+
         if reinterp or not hasattr(self, '_well_smooth_func'):
-            self._well_smooth_func = interp.prep_interp_cubic(self.time_loaded, 
+            self._well_smooth_func = interp.prep_interp_cubic(self.time_loaded,
                                                              self.well_loaded)
 
         if nPoints is not None:
-            self.time = np.linspace(self.time_loaded[0], self.time_loaded[-1], 
+            self.time = np.linspace(self.time_loaded[0], self.time_loaded[-1],
                                     nPoints)
             self.well = self._well_smooth_func(self.time)
 
 
     def calc_separatrix(self):
-        
+
         hamil = pot.potential_to_hamiltonian(self.time, self.well,
-                                             self.beta, self.energy, 
+                                             self.beta, self.energy,
                                              self.eta)
 
         self.upper_energy_bound = np.sqrt(hamil)
-        
+
         sepTime = self.time.tolist() + self.time[::-1].tolist()
         sepEnergy = self.upper_energy_bound.tolist() \
                     + (-self.upper_energy_bound[::-1]).tolist()
-        
+
         self.separatrix = np.array([sepTime, sepEnergy])
 
 
     def basic_parameters(self):
-        
+
         self.half_height = np.max(self.separatrix[1])
         self.area = 2*np.trapz(self.upper_energy_bound, self.time)
         self.length = self.time[-1] - self.time[0]
@@ -239,16 +244,16 @@ class Bucket:
 
     @deco.recursive_function
     def _frequency_distribution(self, trapzThresh = 0):
-        
+
         t, f, h, a, _, _ = pot.synchrotron_frequency_hybrid(self.time,
                                                             self.well,
-                                                            self.eta, 
-                                                            self.beta, 
+                                                            self.eta,
+                                                            self.beta,
                                                             self.energy,
                                        min_potential_well = self.minimum,
                                  inner_max_potential_well = self.inner_max,
                                               trapzThresh = trapzThresh)
-        
+
         self.fsTime = t
         self.fsFreq = f
         self.fsHamil = h
@@ -275,20 +280,20 @@ class Bucket:
         return self.fsArea
 
 
-    def frequency_distribution(self, recalculate = False, old = False, 
+    def frequency_distribution(self, recalculate = False, old = False,
                          trapzThresh = 1):
-        
+
         if recalculate or not hasattr(self, 'sortedTimes'):
             self._calc_inner_max()
             self._frequency_distribution(trapzThresh)
-            
+
             allTimes = []
             allFreqs = []
             for o in zip(self.fsTimes, self.fsFreqs):
                 allTimes += o[0].tolist()
                 allFreqs += o[1].tolist()
             args = np.argsort(allTimes)
-            
+
             self.sortedTimes = np.array(allTimes)[args]
             self.sortedFreqs = np.array(allFreqs)[args]
         else:
@@ -301,23 +306,23 @@ class Bucket:
 
     @deco.recursive_function
     def contains_potential(self, potential):
-        return (potential < np.max(self.well) 
+        return (potential < np.max(self.well)
                 and potential > np.min(self.well))
 
 
     ################################################
     ####Functions for calculating bunch outlines####
     ################################################
-    
-    
+
+
     def _interp_time_from_potential(self, potential, nPts = 0):
-        
+
         if potential > np.max(self.well):
             raise excpt.InputError("Target potential above maximum potential")
-        
+
         if potential < 0:
             raise excpt.InputError("Target potential must be positive")
-        
+
         pts = np.where(self.well <= potential)[0]
         if len(pts) < 2:
             raise excpt.InputError("Too few points below target potential")
@@ -329,7 +334,7 @@ class Bucket:
         if rightPt > len(self.well)-3:
             rightPt += len(self.well) - rightPt - 3
 
-        lTime = np.interp(potential, self.well[leftPt-2:leftPt+2][::-1], 
+        lTime = np.interp(potential, self.well[leftPt-2:leftPt+2][::-1],
                           self.time[leftPt-2:leftPt+2][::-1])
         rTime = np.interp(potential, self.well[rightPt-2:rightPt+3],
                           self.time[rightPt-2:rightPt+3])
@@ -338,15 +343,15 @@ class Bucket:
             return lTime, rTime
         else:
             return np.linspace(lTime, rTime, nPts)
-        
-    
+
+
     def outline_from_length(self, target_length, nPts=1000):
-        
+
         self.smooth_well()
-        
+
         if target_length > self.length:
             raise excpt.BunchSizeError("target_length longer than bucket")
-        
+
         def len_func(potential):
 
             try:
@@ -356,53 +361,53 @@ class Bucket:
 
             return np.abs(target_length - (rTime - lTime))
 
-        result = opt.minimize(len_func, np.max(self.well)/2, 
+        result = opt.minimize(len_func, np.max(self.well)/2,
                               method='Nelder-Mead')
         interpTime = self._interp_time_from_potential(result['x'][0], nPts)
         interpWell = self._well_smooth_func(interpTime)
         interpWell[interpWell>interpWell[0]] = interpWell[0]
-        
-        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime, 
-                                                             interpWell, 
-                                                             self.beta, 
+
+        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime,
+                                                             interpWell,
+                                                             self.beta,
                                                              self.energy,
                                                              self.eta))
 
         outlineTime = interpTime.tolist() + interpTime[::-1].tolist()
         outlineEnergy = energyContour.tolist() \
                         + (-energyContour[::-1]).tolist()
-    
+
         return np.array([outlineTime, outlineEnergy])
 
 
     def outline_from_dE(self, target_height):
-        
+
         self.smooth_well()
-        
+
         if target_height > self.half_height:
             raise excpt.BunchSizeError("target_height higher than bucket")
 
         potential = target_height**2*np.abs(self.eta)\
                         /(2*self.beta**2*self.energy)
-        
+
         interpTime = self._interp_time_from_potential(potential, 1000)
         interpWell = self._well_smooth_func(interpTime)
         interpWell[interpWell>interpWell[0]] = interpWell[0]
-        
-        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime, 
-                                                             interpWell, 
-                                                             self.beta, 
+
+        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime,
+                                                             interpWell,
+                                                             self.beta,
                                                              self.energy,
                                                              self.eta))
-        
+
         outlineTime = interpTime.tolist() + interpTime[::-1].tolist()
         outlineEnergy = energyContour.tolist() \
                         + (-energyContour[::-1]).tolist()
-    
-        
+
+
         return np.array([outlineTime, outlineEnergy])
-    
-    
+
+
     def outline_from_emittance(self, target_emittance, nPts = 1000,
                                over_fill = False):
 
@@ -414,30 +419,30 @@ class Bucket:
                                            + "bucket area")
             else:
                 target_emittance = self.area
-        
+
         def emit_func(potential, *args):
 
             nPts = args[0]
             try:
-                interpTime = self._interp_time_from_potential(potential[0], 
+                interpTime = self._interp_time_from_potential(potential[0],
                                                               nPts)
             except excpt.InputError:
                 return self.area
-            
+
             interpWell = self._well_smooth_func(interpTime)
             interpWell[interpWell>interpWell[0]] = interpWell[0]
-            
-            energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime, 
-                                                             interpWell, 
-                                                             self.beta, 
+
+            energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime,
+                                                             interpWell,
+                                                             self.beta,
                                                              self.energy,
                                                              self.eta))
 
             emittance = 2*np.trapz(energyContour, interpTime)
-            
+
             return np.abs(target_emittance - emittance)
-        
-        result = opt.minimize(emit_func, np.max(self.well)/2, 
+
+        result = opt.minimize(emit_func, np.max(self.well)/2,
                               method='Nelder-Mead', args=(nPts,))
 
         try:
@@ -448,43 +453,43 @@ class Bucket:
         else:
             interpWell = self._well_smooth_func(interpTime)
             interpWell[interpWell>interpWell[0]] = interpWell[0]
-        
-        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime, 
-                                                             interpWell, 
-                                                             self.beta, 
+
+        energyContour = np.sqrt(pot.potential_to_hamiltonian(interpTime,
+                                                             interpWell,
+                                                             self.beta,
                                                              self.energy,
                                                              self.eta))
 
         outlineTime = interpTime.tolist() + interpTime[::-1].tolist()
         outlineEnergy = energyContour.tolist() \
                         + (-energyContour[::-1]).tolist()
-    
-        return np.array([outlineTime, outlineEnergy])    
+
+        return np.array([outlineTime, outlineEnergy])
 
 
     def outline_from_coordinate(self, dt = None, dE = None):
-        
-        dE_array = np.linspace(np.min(self.separatrix[1]), 
+
+        dE_array = np.linspace(np.min(self.separatrix[1]),
                                np.max(self.separatrix[1]),
                                len(self.time))
-        
+
         t_grid, dE_grid = np.meshgrid(self.time, dE_array)
-        
+
         H_grid = (np.abs(self.eta)*dE_grid**2/(2*self.beta**2*self.energy)
                   + np.repeat(np.array([self.well]), len(dE_array), axis=0))
-        
+
         interpFunc = spInterp.interp2d(t_grid[0], dE_grid[:,0], H_grid)
         hamVal = interpFunc(dt, dE)
-        contour = np.sqrt((hamVal - self.well) * 2*self.beta**2 
+        contour = np.sqrt((hamVal - self.well) * 2*self.beta**2
                           * self.energy/np.abs(self.eta))
-        
+
         outlineTime = self.time[np.isnan(contour) != True]
         outlineEnergy = contour[np.isnan(contour) != True]
-        
+
         outlineTime = outlineTime.tolist() + outlineTime[::-1].tolist()
         outlineEnergy = outlineEnergy.tolist() \
                         + (-outlineEnergy[::-1]).tolist()
-        
+
         return np.array([outlineTime, outlineEnergy])
 
 
@@ -495,13 +500,13 @@ class Bucket:
 
     def _set_bunch(self, bunch_length = None, bunch_emittance = None,
                            bunch_height = None, over_fill = False):
-        
+
         allowed = ('bunch_length', 'bunch_emittance', 'bunch_height')
         assrt.single_not_none(bunch_length, bunch_emittance, bunch_height,
                               msg = 'Exactly 1 of ' + str(allowed) \
-                              + ' should be given', 
+                              + ' should be given',
                               exception = excpt.InputError)
-        
+
         if bunch_length is not None:
             if bunch_length == 0:
                 outline = [[0, 0], [0,0]]
@@ -511,14 +516,14 @@ class Bucket:
             if bunch_emittance == 0:
                 outline = [[0, 0], [0,0]]
             else:
-                outline = self.outline_from_emittance(bunch_emittance, 
+                outline = self.outline_from_emittance(bunch_emittance,
                                                       over_fill = over_fill)
         elif bunch_height is not None:
             if bunch_height == 0:
                 outline = [[0, 0], [0,0]]
             else:
                 outline = self.outline_from_dE(bunch_height)
-        
+
         self._bunch_length = np.max(outline[0]) - np.min(outline[0])
         self._bunch_height = np.max(outline[1])
         self._bunch_emittance = np.trapz(outline[1], outline[0])
@@ -527,64 +532,64 @@ class Bucket:
     @property
     def bunch_length(self):
         return self._bunch_length
-    
+
     @property
     def bunch_height(self):
         return self._bunch_height
-    
+
     @property
     def bunch_emittance(self):
         return self._bunch_emittance
-    
-    
+
+
     @bunch_length.setter
     def bunch_length(self, value):
         self._set_bunch(bunch_length = value)
-    
+
     @bunch_height.setter
     def bunch_height(self, value):
         self._set_bunch(bunch_height = value)
-    
+
     @bunch_emittance.setter
     def bunch_emittance(self, value):
         self._set_bunch(bunch_emittance = value)
-        
-        
+
+
     ###################################################
     ####Functions for generation bunches parameters####
     ###################################################
-        
-    
-    def make_profiles(self, dist_type, length = None, emittance = None, 
+
+
+    def make_profiles(self, dist_type, length = None, emittance = None,
                       dE = None, use_action = False, recalculate = False,
                       over_fill = False):
-        
+
         if not recalculate and hasattr(self, 'time_profile'):
             return
-        
+
         if not all(par is None for par in (length, emittance, dE)):
             self._set_bunch(length, emittance, dE, over_fill)
-        
-        self.dE_array = np.linspace(np.min(self.separatrix[1]), 
+
+        self.dE_array = np.linspace(np.min(self.separatrix[1]),
                                     np.max(self.separatrix[1]), len(self.time))
-        
+
         self.compute_action()
-        
+
         if use_action:
             size = self.bunch_emittance / (2*np.pi)
         else:
-            size = np.interp(self.bunch_emittance / (2*np.pi), 
-                             self.J_array[self.J_array.argsort()], 
+            size = np.interp(self.bunch_emittance / (2*np.pi),
+                             self.J_array[self.J_array.argsort()],
                              self.well[self.well.argsort()])
-        
-        profiles = matchDist.matched_profile(dist_type, size, self.time, 
-                                             self.well, self.dE_array, 
+
+        profiles = matchDist.matched_profile(dist_type, size, self.time,
+                                             self.well, self.dE_array,
                                              self.beta, self.energy, self.eta)
 
         self.time_profile, self.energy_profile = profiles
 
     def compute_action(self):
-    
+
         J_array = np.zeros(len(self.time))
         for i in range(len(self.time)):
             useWell = self.well[self.well < self.well[i]]
@@ -592,7 +597,7 @@ class Bucket:
             contour = np.sqrt(np.abs((self.well[i] - useWell)*2
                               *self.beta**2*self.energy/self.eta))
             J_array[i] = np.trapz(contour, useTime)/np.pi
-    
+
         self.J_array = J_array
 
 

--- a/datatypes/beam_data.py
+++ b/datatypes/beam_data.py
@@ -54,7 +54,7 @@ class _beam_data(_function):
     """
     
     def __new__(cls, *args, units, time = None, n_turns = None, 
-                interpolation = 'linear', **kwargs):
+                interpolation = 'linear', dtype=None, **kwargs):
         
         _check_time_turns(time, n_turns)
             
@@ -79,7 +79,8 @@ class _beam_data(_function):
         data_type = {'timebase': data_types[0], 'bunching': bunching,
                      'units': units, **kwargs}
         
-        return super().__new__(cls, data_points, data_type, interpolation)
+        return super().__new__(cls, data_points, data_type, interpolation,
+                               dtype)
 
 
     @property
@@ -154,11 +155,11 @@ class acceptance(_beam_data):
     """
     
     def __new__(cls, *args, units = 'eVs', time = None, n_turns = None, 
-                interpolation = 'linear'):
+                interpolation = 'linear', dtype=None):
         
         return super().__new__(cls, *args, units = units, time = time, 
                                n_turns = n_turns, 
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
 class emittance(_beam_data):
@@ -205,13 +206,14 @@ class emittance(_beam_data):
     """
     
     def __new__(cls, *args, emittance_type = 'matched_area', units = 'eVs', 
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, 
                                emittance_type = emittance_type,
                                units = units, time = time, 
                                n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -275,12 +277,13 @@ class length(_beam_data):
     """
     
     def __new__(cls, *args, length_type = 'full_length', units = 's',
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, length_type = length_type, 
                                units = units, time = time, 
                                n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -343,11 +346,12 @@ class height(_beam_data):
     """
     
     def __new__(cls, *args, height_type = 'half_height', units = 'eV',
-                time = None, n_turns = None, interpolation = 'linear'):
+                time = None, n_turns = None, interpolation = 'linear',
+                dtype=None):
         
         return super().__new__(cls, *args, height_type = height_type, 
                                units = units, time = time, n_turns = n_turns,
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)
 
 
     @property
@@ -403,8 +407,8 @@ class synchronous_phase(_beam_data):
     """
     
     def __new__(cls, *args, units = 's', time = None, n_turns = None, 
-                interpolation = 'linear'):
+                interpolation = 'linear', dtype=None):
         
         return super().__new__(cls, *args, units = units, time = time, 
                                n_turns = n_turns, 
-                               interpolation = interpolation)
+                               interpolation = interpolation, dtype=dtype)

--- a/datatypes/functions.py
+++ b/datatypes/functions.py
@@ -137,6 +137,11 @@ def vstack(*args, interpolation = 'linear'):
             for n in range(nSections):
                 subFunctions[n] += reshaped[n].tolist()
         
+        if not all(np.diff(useTimes) > 0):
+            raise RuntimeError("Resulting time is not monotonically "
+                               +"increasing, check start and stop times, "
+                               +"and/or function time values.")
+        
         newArray = functions[0].__class__.zeros([nSections, 2, len(useTimes)])
         for i, f in enumerate(subFunctions):
             newArray[i] = [useTimes, f]

--- a/interfaces/beam/beam_parameters.py
+++ b/interfaces/beam/beam_parameters.py
@@ -298,47 +298,7 @@ class Beam_Parameters:
         times, wells = pot.potential_well_cut_cubic(inTime, inWell, maxLocs)
         particleLoc = self.particle_tracks[particle][sample]
         
-        # plt.plot(inTime, inWell)
-        # for i, (t, w) in enumerate(zip(times, wells)):
-        #     plt.plot(t, w+i*100)
-        # plt.axvline(particleLoc, color='red')
-#        for locs in maxLocs:
-#            for l in locs:
-#                plt.axvline(l)
-        # plt.show()
-#        
-#        sys.exit()
-        
-        #Check which subwells contain current particle
-        relevant = [i for i, t in enumerate(times) if particleLoc>t[0] and 
-                                                      particleLoc<t[-1]]
-
-        subTime = [times[r] for r in relevant]
-        subWell = [wells[r] for r in relevant]
-        try:
-            biggest = pot.sort_potential_wells(subTime, subWell, by='size')[0][0]
-        except:
-            plt.clf()
-            plt.plot(inTime, inWell)
-            plt.axvline(particleLoc)
-            plt.show()
-            print(maxLocs, particleLoc)
-            print(f"Sample: {sample}")
-            # np.save('heavyBeamLoadingWell2', [inTime, inWell])
-            raise
-
-        #check which subwells are within the bounds of the largest well 
-        #containing the current particle
-        relevant = [i for i, t in enumerate(times) if t[0] >= biggest[0] and
-                                                      t[-1] <= biggest[-1]]
-        
-        times = [times[r] for r in relevant]
-        wells = [wells[r] for r in relevant]
-
-        mins = [np.min(w) for w in wells]
-        wells -= np.min(mins)
-        
-        times, wells = pot.sort_potential_wells(times, wells, by='t_start')
+        times, wells = pot.choose_potential_wells(particleLoc, times, wells)
         
         return times, wells
     

--- a/interfaces/impedances/impedance_sources.py
+++ b/interfaces/impedances/impedance_sources.py
@@ -177,11 +177,11 @@ class _InputTable(_ImpedanceObject):
         self.impedance_loaded = (self.Re_Z_array_loaded + 1j *
                                  self.Im_Z_array_loaded)
 
-#        if self.frequency_array_loaded[0] != 0:
-#            self.frequency_array_loaded = np.hstack(
-#                (0, self.frequency_array_loaded))
-#            self.Re_Z_array_loaded = np.hstack((0, self.Re_Z_array_loaded))
-#            self.Im_Z_array_loaded = np.hstack((0, self.Im_Z_array_loaded))
+        if self.frequency_array_loaded[0] != 0:
+            self.frequency_array_loaded = np.hstack(
+                (0, self.frequency_array_loaded))
+            self.Re_Z_array_loaded = np.hstack((0, self.Re_Z_array_loaded))
+            self.Im_Z_array_loaded = np.hstack((0, self.Im_Z_array_loaded))
         
         self.imped_calc(frequency)
 

--- a/interfaces/induced_voltage/induced_voltage.py
+++ b/interfaces/induced_voltage/induced_voltage.py
@@ -118,12 +118,13 @@ class InducedVoltage:
         varImpedances = [i for i in self.var_impedances_loaded]
         
         for i in impedances:
-            i.update(f_rev)
+            # i.update(f_rev)
             i.imped_calc(self.interp_frequency_array)
             self.imped_induced.append(calc_induced_freq(self.beam_spectrum, 
                                                    i.impedance*normalisation))
         
         for i in varImpedances:
+            i.update(f_rev)
             i.imped_calc(self.interp_frequency_array)
             self.var_imped_induced.append(calc_induced_freq(self.beam_spectrum, 
                                                    i.impedance*normalisation))
@@ -207,6 +208,7 @@ def calc_induced_time(profile, wake):
 
 def calc_induced_inductive(derivative, inductive):
     return -derivative*inductive
+    # return derivative*inductive
         
         
 

--- a/interfaces/machine_parameters/ring_section.py
+++ b/interfaces/machine_parameters/ring_section.py
@@ -192,16 +192,17 @@ class RingSection:
 
             # orbit_bump was checked
             # The length attribute is created with no further checks
-            if orbit_bump.timebase == 'by_time':
+            self.length = self.orbit_bump + self.length_design
+            # if orbit_bump.timebase == 'by_time':
 
-                self.length = ring_programs.orbit_length_program(
-                    [self.length_design] * len(self.orbit_bump[0, 0, :]),
-                    time=self.orbit_bump[0, 0, :])
-                self.length[:, 1, :] += self.orbit_bump[:, 1, :]
+            #     self.length = ring_programs.orbit_length_program(
+            #         [self.length_design] * len(self.orbit_bump[0, 0, :]),
+            #         time=self.orbit_bump[0, 0, :])
+            #     self.length[:, 1, :] += self.orbit_bump[:, 1, :]
 
-            else:
+            # else:
 
-                self.length = self.orbit_bump + self.length_design
+            #     self.length = self.orbit_bump + self.length_design
 
         # Setting the linear momentum compaction factor
         # Checking that the synchronous data and the momentum compaction

--- a/rf_functions/potential.py
+++ b/rf_functions/potential.py
@@ -851,3 +851,28 @@ def voltage_from_single_h_tune(energy, beta, delta_E, eta, charge, harmonic,
     heeta = harmonic*charge*np.abs(eta)
         
     return np.sqrt(delta_E**2 + (twoPiBetaE*tune**2/heeta)**2)
+
+
+def choose_potential_wells(phis, times, wells):
+    
+    relevant = [i for i, t in enumerate(times) if phis>t[0] and 
+                                                      phis<t[-1]]
+
+    subTime = [times[r] for r in relevant]
+    subWell = [wells[r] for r in relevant]
+    biggest = sort_potential_wells(subTime, subWell, by='size')[0][0]
+
+    #check which subwells are within the bounds of the largest well 
+    #containing the current particle
+    relevant = [i for i, t in enumerate(times) if t[0] >= biggest[0] and
+                                                  t[-1] <= biggest[-1]]
+    
+    times = [times[r] for r in relevant]
+    wells = [wells[r] for r in relevant]
+
+    mins = [np.min(w) for w in wells]
+    wells -= np.min(mins)
+    
+    times, wells = sort_potential_wells(times, wells, by='t_start')
+    
+    return times, wells

--- a/utilities/rel_transforms.py
+++ b/utilities/rel_transforms.py
@@ -229,5 +229,20 @@ def B_field_to_kin_energy(B_Field, bending_radius, charge, rest_mass=None,
     return kin_energy
 
 
+def delta_P_to_delta_E(deltaP, momentum, rest_mass=None, n_nuc=None, atomic_mass=None):
+
+    rest_mass = _get_mass(rest_mass, n_nuc, atomic_mass)
+
+    energy = momentum_to_energy(momentum, rest_mass)
+    deltaE = energy - np.sqrt(rest_mass**2 + (deltaP + momentum)**2)
     
+    return deltaE
+
+def delta_E_to_delta_P(deltaE, energy, rest_mass=None, n_nuc=None, atomic_mass=None):
+
+    rest_mass = _get_mass(rest_mass, n_nuc, atomic_mass)
+
+    momentum = energy_to_momentum(energy, rest_mass)
+    deltaP = energy - np.sqrt(rest_mass**2 + (deltaE + momentum)**2)
     
+    return deltaP


### PR DESCRIPTION
- Unit tests for all datatypes modules
- `store_time` argument for `_core.reshape`, also implemented in the `_RF_Programs` version.
- Added `dtype` kwarg throughout to allow specifying if data is a float etc
- Implemented `+, +=, *, *=, /, /=,<,<=,>,>=` operators and functionality to allow more to be implemented in the future correctly handling the time axis for functions defined 'by_time'
- Made `interpolation` part of the `data_type` dictionary to include it in the copying etc
- Covered requirements for issue  #47 
- Added `choose_potential_wells` function to potential.py to select all potential wells that contain a specified particle.